### PR TITLE
Added env AWS_REGIONS to docker-compose and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 # Project variables
 export PROJECT_NAME ?= squid
+export AWS_REGIONS ?= us-east-1
+
 ORG_NAME ?= cwds
 REPO_NAME ?= squid
 DOCKER_REGISTRY ?= 429614120872.dkr.ecr.us-west-2.amazonaws.com
@@ -7,7 +9,7 @@ AWS_ACCOUNT_ID ?= 429614120872
 DOCKER_LOGIN_EXPRESSION ?= $$(aws ecr get-login --registry-ids $(AWS_ACCOUNT_ID))
 
 # Release settings
-export SQUID_WHITELIST ?= 
+export SQUID_WHITELIST ?=
 export NO_WHITELIST ?= false
 
 # Common settings

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ devicefarm.us-west-2.amazonaws.com
 importexport.amazonaws.com
 ```
 
-### Squid Configuration 
+### Squid Configuration
 
 The following table defines environment variables control the configuration of containers created from this image.
 
@@ -148,3 +148,10 @@ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
 
 See www.gnu.org/licenses/agpl.html
+
+## Release Notes
+
+### Version 0.0.1
+
+- **BUG FIX** : Added env AWS_REGIONS, with default, to Makefile and included in docker-compose environments stanza `https://github.com/Casecommons/docker-squid/pull/1`
+

--- a/docker/release/docker-compose.yml
+++ b/docker/release/docker-compose.yml
@@ -12,4 +12,5 @@ services:
     environment:
       NO_WHITELIST: ${NO_WHITELIST}
       SQUID_WHITELIST: ${SQUID_WHITELIST}
+      AWS_REGIONS: ${AWS_REGIONS}
       SHUTDOWN_LIFETIME: "0"


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/148768631

Allows for passing .us-east-1.amazonaws.com to squid whitelist:
https://github.com/Casecommons/docker-squid/blob/master/src/etc/confd/templates/whitelist.txt.tmpl#L2
https://github.com/Casecommons/docker-squid

@pemacc ^^
